### PR TITLE
fix: ignore wild sketch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+~`~sketchFile.sketch


### PR DESCRIPTION
Lunacy was adding a strangely named sketch file to the directory when it was open. This PR ignores that file so I can use `git add .` without worry. 